### PR TITLE
Fix for images (metadata) disappearing

### DIFF
--- a/struct_sd.go
+++ b/struct_sd.go
@@ -232,7 +232,7 @@ type SDProgram struct {
 	} `json:"titles"`
 }
 
-//SDMetadata : Schedules Direct meta data
+// SDMetadata : Schedules Direct meta data
 type SDMetadata struct {
 	Data      []Data `json:"data",required`
 	ProgramID string `json:"programID"`
@@ -240,10 +240,10 @@ type SDMetadata struct {
 
 type Data struct {
 	Aspect   string `json:"aspect"`
-	Height   string `json:"height"`
+	Height   int    `json:"height"`
 	Size     string `json:"size"`
 	URI      string `json:"uri"`
-	Width    string `json:"width"`
+	Width    int    `json:"width"`
 	Category string `json:"category"`
 	Tier     string `json:"tier"`
 }


### PR DESCRIPTION
SD sends down image height and width as ints, not strings.  This was failing in the JSON parser.

- Changed the type for height and width to be int, and slight refactoring of the code that uses them to reflect this
- Size might be a future problem (?), but I don't have an SD feed that includes size.  Something to watch out for.
- I added some improved logging to help detect such problems in the future (as long as "Shown download errors ..." is set in the config).